### PR TITLE
Improve poller crash handling

### DIFF
--- a/lib/dawdle/poller/poller.ex
+++ b/lib/dawdle/poller/poller.ex
@@ -30,13 +30,7 @@ defmodule Dawdle.Poller do
     |> send_to.recv()
 
     source.delete(queue, messages)
-  rescue
-    exception ->
-      Logger.error("""
-      Dawdle poller crash: #{inspect(exception)}
-        #{inspect(__STACKTRACE__, pretty: true)}
-      """)
-  after
+
     poll(source, queue, send_to)
   end
 


### PR DESCRIPTION
Remove the aggressive exception handling in the poller and "let it crash." The supervisor will take care of logging and restarting the poller. The supervisor has built-in crashloop protection, neatly solving our problem with less code.