### PR TITLE
Improve message throughput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Configuration requires queue URLs instead of just queue names
+- Use a single queue for all types of messages.
+- Configuration requires a queue URL instead of a queue name.
+- Removed batch signaling. This complicated the code and wasn't a good fit for
+the overall design of Dawdle.
+- Removed the deprecated 0.4.x API.
+
+### Fixed
+- Long message processing times can cause the SQS queue to be clogged.
+
+### Added
+- Log unhandled messages.
 
 ## [0.6.1] - 2019-07-29
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ config :dawdle, Dawdle.Backend.SQS,
 ```
 
 These values can also be set by using the environment variables
-`DAWDLE_SQS_REGION`, `DAWDLE_SQS_DELAY_QUEUE`, and `DAWDLE_SQS_MESSAGE_QUEUE`.
+`DAWDLE_SQS_REGION` and `DAWDLE_SQS_QUEUE_URL`.
 
 The configuration should be managed either via `config.exs` or by setting the
 environment variables. Trying to mix the two will result in some changes being

--- a/README.md
+++ b/README.md
@@ -52,13 +52,12 @@ config :dawdle,
 You can also set the environment variables `DAWDLE_BACKEND` or
 `DAWDLE_START_LISTENER`.
 
-To configure your SQS queues, set queue URL in `config.exs`:
+To configure your SQS queue, set the queue URL in `config.exs`:
 
 ```elixir
 config :dawdle, Dawdle.Backend.SQS,
     region: "us-east-1",
-    delay_queue: "https://sqs.us-east-1.amazonaws.com/XXXXXXXXXXXX/my-dawdle-delay-queue",
-    message_queue: "https://sqs.us-east-1.amazonaws.com/XXXXXXXXXXXX/my-dawdle-message-queue"
+    queue_url: "https://sqs.us-east-1.amazonaws.com/XXXXXXXXXXXX/my-dawdle-message-queue"
 ```
 
 These values can also be set by using the environment variables
@@ -69,32 +68,28 @@ environment variables. Trying to mix the two will result in some changes being
 overwritten in surprising ways. Caveat emptor.
 
 
-## Setting Up Your SQS Queues
+## Setting Up Your SQS Queue
 
-Obviously the configured SQS queues need to exist and be accessible by your
+Obviously the configured SQS queue needs to exist and be accessible by your
 application. AWS authentication is handled by
 [ex_aws](https://github.com/ex-aws/ex_aws). If you're already using `ex_aws` for
 something else, your configuration should already be good. If not, follow the
 configuration instructions on that page to set up your AWS key.
 
 Dawdle uses two queues: one for normal messages and one for delayed events. The
-message queue *must* be a FIFO Queue and the delay queue *must* be a Standard
-Queue. They can be configured with default values, __except__ that
-`Receive Message Wait Time` should be set to 20 seconds to enable long polling.
+message queue *must* be a Standard Queue. They can be configured with default
+values, __except__ that `Receive Message Wait Time` should be set to 20 seconds
+to enable long polling. It is also a good idea to set `Default Visibility Timeout`
+to a short value, like 2 seconds.
 
-The queues can be created using the `aws` CLI or from the AWS Control Panel.
+The queue can be created using the `aws` CLI or from the AWS Control Panel.
 
-Here are example commands for creating the queues from the CLI:
+Here are example commands for creating the queue from the CLI:
 
 ```
-$ aws sqs create-queue --queue-name my-dawdle-delay-queue --attributes ReceiveMessageWaitTimeSeconds=20
+$ aws sqs create-queue --queue-name my-dawdle-message-queue --attributes ReceiveMessageWaitTimeSeconds=20
 {
-    "QueueUrl": "https://xx-xxxx-x.queue.amazonaws.com/XXXXXXXXXXXX/my-dawdle-delay-queue"
-}
-
-$ aws sqs create-queue --queue-name my-dawdle-message-queue.fifo --attributes FifoQueue=true,ReceiveMessageWaitTimeSeconds=20
-{
-    "QueueUrl": "https://xx-xxxx-x.queue.amazonaws.com/XXXXXXXXXXXX/my-dawdle-message-queue.fifo"
+    "QueueUrl": "https://xx-xxxx-x.queue.amazonaws.com/XXXXXXXXXXXX/my-dawdle-message-queue"
 }
 ```
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -15,6 +15,7 @@ config :ex_aws,
 
 config :dawdle, Dawdle.Backend.SQS,
   region: "us-west-2",
-  queue_url: "https://sqs.us-west-2.amazonaws.com/XXXXXXXXXXXX/hippware-dawdle-message-test"
+  queue_url:
+    "https://sqs.us-west-2.amazonaws.com/XXXXXXXXXXXX/hippware-dawdle-message-test"
 
 config :logger, level: :info

--- a/config/config.exs
+++ b/config/config.exs
@@ -16,6 +16,6 @@ config :ex_aws,
 config :dawdle, Dawdle.Backend.SQS,
   region: "us-west-2",
   queue_url:
-    "https://sqs.us-west-2.amazonaws.com/XXXXXXXXXXXX/hippware-dawdle-message-test"
+    "https://sqs.us-west-2.amazonaws.com/XXXXXXXXXXXX/hippware-dawdle-test"
 
 config :logger, level: :info

--- a/config/config.exs
+++ b/config/config.exs
@@ -15,9 +15,6 @@ config :ex_aws,
 
 config :dawdle, Dawdle.Backend.SQS,
   region: "us-west-2",
-  delay_queue:
-    "https://sqs.us-west-2.amazonaws.com/XXXXXXXXXXXX/hippware-dawdle-delay-test",
-  message_queue:
-    "https://sqs.us-west-2.amazonaws.com/XXXXXXXXXXXX/hippware-dawdle-message-test.fifo"
+  queue_url: "https://sqs.us-west-2.amazonaws.com/XXXXXXXXXXXX/hippware-dawdle-message-test"
 
 config :logger, level: :info

--- a/lib/dawdle.ex
+++ b/lib/dawdle.ex
@@ -145,24 +145,4 @@ defmodule Dawdle do
   """
   @spec call_after(duration(), fun()) :: :ok | {:error, term()}
   defdelegate call_after(delay, fun), to: Dawdle.Delay.Handler
-
-  # Old 0.4.x API (deprecated)
-
-  @doc """
-  (DEPRECATED) Set a callback to be called the eafter `delay` ms
-
-  ## Examples
-
-  ```
-  iex> Dawdle.call_after(fn _arg ->
-  ...> # Do something later...
-  ...> :ok
-  ...> end, 1, 5)
-  :ok
-  """
-  @deprecated "Use call_after/2 or signal/2 instead"
-  @spec call_after(callback(), argument(), duration()) :: :ok | {:error, term()}
-  def call_after(callback, argument, delay) do
-    call_after(delay, fn -> callback.(argument) end)
-  end
 end

--- a/lib/dawdle.ex
+++ b/lib/dawdle.ex
@@ -33,7 +33,7 @@ defmodule Dawdle do
   Dawdle.signal(%MyApp.TestEvent{foo: 1, bar: 2}, delay: 5)
   ```
   """
-  @spec signal(event() | [event()], Keyword.t()) :: :ok | {:error, term()}
+  @spec signal(event(), Keyword.t()) :: :ok | {:error, term()}
   defdelegate signal(event, opts \\ []), to: Dawdle.Client
 
   @doc """

--- a/lib/dawdle/backend/backend.ex
+++ b/lib/dawdle/backend/backend.ex
@@ -7,7 +7,7 @@ defmodule Dawdle.Backend do
 
   @type queue :: binary()
   @type send_message :: binary()
-  @type recv_message :: map()
+  @type recv_message :: %{body: binary()}
   @type delay_secs :: non_neg_integer()
 
   @callback init() :: :ok

--- a/lib/dawdle/backend/backend.ex
+++ b/lib/dawdle/backend/backend.ex
@@ -11,11 +11,11 @@ defmodule Dawdle.Backend do
   @type delay_secs :: non_neg_integer()
 
   @callback init() :: :ok
-  @callback queues() :: [queue()]
+  @callback queue() :: queue()
   @callback send([send_message()]) :: :ok | {:error, term()}
   @callback send_after(send_message(), delay_secs()) :: :ok | {:error, term()}
-  @callback recv(queue()) :: {:ok, [recv_message()]} | {:error, term()}
-  @callback delete(queue(), [recv_message()]) :: :ok
+  @callback recv() :: {:ok, [recv_message()]} | {:error, term()}
+  @callback delete([recv_message()]) :: :ok
 
   @doc """
   Returns an initialized backend.

--- a/lib/dawdle/backend/backend.ex
+++ b/lib/dawdle/backend/backend.ex
@@ -7,15 +7,15 @@ defmodule Dawdle.Backend do
 
   @type queue :: binary()
   @type send_message :: binary()
-  @type recv_message :: %{body: binary()}
+  @type recv_message :: map()
   @type delay_secs :: non_neg_integer()
 
   @callback init() :: :ok
   @callback queue() :: queue()
-  @callback send([send_message()]) :: :ok | {:error, term()}
+  @callback send(send_message()) :: :ok | {:error, term()}
   @callback send_after(send_message(), delay_secs()) :: :ok | {:error, term()}
   @callback recv() :: {:ok, [recv_message()]} | {:error, term()}
-  @callback delete([recv_message()]) :: :ok
+  @callback delete(recv_message()) :: :ok
 
   @doc """
   Returns an initialized backend.

--- a/lib/dawdle/backend/local.ex
+++ b/lib/dawdle/backend/local.ex
@@ -22,7 +22,7 @@ defmodule Dawdle.Backend.Local do
   end
 
   @impl true
-  def queues, do: ["local"]
+  def queue, do: "local"
 
   @impl true
   def send(messages), do: GenServer.cast(__MODULE__, {:send, messages})
@@ -37,10 +37,10 @@ defmodule Dawdle.Backend.Local do
   end
 
   @impl true
-  def recv(_), do: GenServer.call(__MODULE__, :recv, :infinity)
+  def recv, do: GenServer.call(__MODULE__, :recv, :infinity)
 
   @impl true
-  def delete(_, _), do: :ok
+  def delete(_), do: :ok
 
   @doc false
   @spec count :: :non_neg_integer

--- a/lib/dawdle/backend/local.ex
+++ b/lib/dawdle/backend/local.ex
@@ -25,14 +25,14 @@ defmodule Dawdle.Backend.Local do
   def queue, do: "local"
 
   @impl true
-  def send(messages), do: GenServer.cast(__MODULE__, {:send, messages})
+  def send(message), do: GenServer.cast(__MODULE__, {:send, message})
 
   @impl true
   def send_after(message, delay) do
     # The SQS backend interprets the delay as seconds, whereas here we are
     # interpreting it as milliseconds. This is to allow us to test the delay
     # feature without the tests taking forever.
-    {:ok, _} = :timer.apply_after(delay, __MODULE__, :send, [[message]])
+    {:ok, _} = :timer.apply_after(delay, __MODULE__, :send, [message])
     :ok
   end
 
@@ -56,13 +56,13 @@ defmodule Dawdle.Backend.Local do
   end
 
   @impl true
-  def handle_cast({:send, messages}, {[], [waiter | rest]}) do
-    GenServer.reply(waiter, {:ok, transform_messages(messages)})
+  def handle_cast({:send, message}, {[], [waiter | rest]}) do
+    GenServer.reply(waiter, {:ok, [transform_message(message)]})
     {:noreply, {[], rest}}
   end
 
-  def handle_cast({:send, messages}, {queue, []}) do
-    {:noreply, {queue ++ transform_messages(messages), []}}
+  def handle_cast({:send, message}, {queue, []}) do
+    {:noreply, {[transform_message(message) | queue], []}}
   end
 
   @impl true
@@ -71,7 +71,7 @@ defmodule Dawdle.Backend.Local do
   end
 
   def handle_call(:recv, _from, {messages, []}) do
-    {:reply, {:ok, messages}, {[], []}}
+    {:reply, {:ok, Enum.reverse(messages)}, {[], []}}
   end
 
   def handle_call(:flush, _from, _) do
@@ -82,7 +82,5 @@ defmodule Dawdle.Backend.Local do
     {:reply, length(messages), state}
   end
 
-  defp transform_messages(messages) do
-    Enum.map(messages, fn m -> %{body: m} end)
-  end
+  defp transform_message(message), do: %{body: message}
 end

--- a/lib/dawdle/client.ex
+++ b/lib/dawdle/client.ex
@@ -237,7 +237,7 @@ defmodule Dawdle.Client do
     results = Enum.map(handlers, &maybe_call_handler(&1, object, event))
 
     _ =
-      unless Enum.all?(results, & &1) do
+      unless Enum.any?(results, & &1) do
         Logger.warn("Unhandled event: #{inspect(event, pretty: true)}")
       end
 

--- a/lib/dawdle/message_encoder/message_encoder.ex
+++ b/lib/dawdle/message_encoder/message_encoder.ex
@@ -12,16 +12,16 @@ defmodule Dawdle.MessageEncoder do
   @doc """
   Encode an event into a string that is safe to enqueue.
   """
-  @callback encode(event :: any()) :: String.t()
+  @callback encode(event :: any()) :: {:ok, String.t()} | {:error, any()}
 
   @doc """
   Decode a string pulled from the queue into its original representation.
   """
-  @callback decode(message :: String.t()) :: any()
+  @callback decode(message :: String.t()) :: {:ok, any()} | {:error, any()}
 
   @default_encoder Dawdle.MessageEncoder.Term
 
-  @spec encode(any()) :: String.t()
+  @spec encode(any()) :: {:ok, String.t()} | {:error, any()}
   def encode(event) do
     encoder = get_encoder()
 
@@ -32,7 +32,7 @@ defmodule Dawdle.MessageEncoder do
     )
   end
 
-  @spec decode(String.t()) :: any()
+  @spec decode(String.t()) :: {:ok, any()} | {:error, any()}
   def decode(message) do
     encoder = get_encoder()
 

--- a/lib/dawdle/message_encoder/term.ex
+++ b/lib/dawdle/message_encoder/term.ex
@@ -10,15 +10,24 @@ defmodule Dawdle.MessageEncoder.Term do
 
   @impl true
   def encode(data) do
-    data
-    |> :erlang.term_to_binary()
-    |> Base.encode64()
+    string =
+      data
+      |> :erlang.term_to_binary(compressed: 6, minor_version: 2)
+      |> Base.encode64(padding: false)
+
+    {:ok, string}
   end
 
   @impl true
   def decode(string) do
-    string
-    |> Base.decode64!()
-    |> :erlang.binary_to_term()
+    term =
+      string
+      |> Base.decode64!(ignore: :whitespace, padding: false)
+      |> :erlang.binary_to_term()
+
+    {:ok, term}
+  rescue
+    ArgumentError ->
+      {:error, :unrecognized}
   end
 end

--- a/lib/dawdle/poller/supervisor.ex
+++ b/lib/dawdle/poller/supervisor.ex
@@ -16,12 +16,8 @@ defmodule Dawdle.Poller.Supervisor do
   end
 
   @spec start_pollers(module(), module()) :: :ok
-  def start_pollers(backend, send_to) do
-    Enum.each(backend.queues(), &start_poller(backend, &1, send_to))
-  end
-
-  defp start_poller(source, queue, send_to) do
-    case Supervisor.start_child(__MODULE__, {Poller, {source, queue, send_to}}) do
+  def start_pollers(source, send_to) do
+    case Supervisor.start_child(__MODULE__, {Poller, {source, send_to}}) do
       {:ok, _} -> :ok
       {:error, {:already_started, _}} -> :ok
     end

--- a/mix.exs
+++ b/mix.exs
@@ -43,9 +43,7 @@ defmodule Dawdle.MixProject do
         start_pollers: {:system, :boolean, "DAWDLE_START_POLLERS", false},
         "Elixir.Dawdle.Backend.SQS": [
           region: {:system, "DAWDLE_SQS_REGION", "us-west-2"},
-          delay_queue: {:system, "DAWDLE_SQS_DELAY_QUEUE", "dawdle-delay"},
-          message_queue:
-            {:system, "DAWDLE_SQS_MESSAGE_QUEUE", "dawdle-messages.fifo"}
+          queue_url: {:system, "DAWDLE_SQS_QUEUE_URL", ""}
         ]
       ]
     ]

--- a/test/dawdle/backend/local_test.exs
+++ b/test/dawdle/backend/local_test.exs
@@ -11,11 +11,9 @@ defmodule Dawdle.Backend.LocalTest do
   end
 
   setup do
-    [queue] = Local.queues()
-
     Local.flush()
 
-    {:ok, queue: queue}
+    :ok
   end
 
   describe "send/1" do
@@ -59,29 +57,29 @@ defmodule Dawdle.Backend.LocalTest do
     end
   end
 
-  describe "recv/1" do
-    test "receiving a message", %{queue: q} do
+  describe "recv/0" do
+    test "receiving a message" do
       message = Lorem.sentence()
 
       :ok = Local.send([message])
 
-      assert {:ok, [message]} = Local.recv(q)
+      assert {:ok, [message]} = Local.recv()
     end
 
-    test "receiving multiple messages", %{queue: q} do
+    test "receiving multiple messages" do
       message1 = Lorem.sentence()
       message2 = Lorem.sentence()
 
       :ok = Local.send([message1, message2])
 
-      assert {:ok, [message1, message2]} = Local.recv(q)
+      assert {:ok, [message1, message2]} = Local.recv()
     end
 
-    test "receiving from an empty queue", %{queue: q} do
+    test "receiving from an empty queue" do
       message = Lorem.sentence()
 
       Task.start(fn ->
-        assert {:ok, [message]} = Local.recv(q)
+        assert {:ok, [message]} = Local.recv()
       end)
 
       Process.sleep(10)

--- a/test/dawdle/backend/local_test.exs
+++ b/test/dawdle/backend/local_test.exs
@@ -20,7 +20,7 @@ defmodule Dawdle.Backend.LocalTest do
     test "sending a single message" do
       message = Lorem.sentence()
 
-      :ok = Local.send([message])
+      :ok = Local.send(message)
 
       assert Local.count() == 1
     end
@@ -29,17 +29,8 @@ defmodule Dawdle.Backend.LocalTest do
       message1 = Lorem.sentence()
       message2 = Lorem.sentence()
 
-      :ok = Local.send([message1])
-      :ok = Local.send([message2])
-
-      assert Local.count() == 2
-    end
-
-    test "sending multiple messages" do
-      message1 = Lorem.sentence()
-      message2 = Lorem.sentence()
-
-      :ok = Local.send([message1, message2])
+      :ok = Local.send(message1)
+      :ok = Local.send(message2)
 
       assert Local.count() == 2
     end
@@ -61,7 +52,7 @@ defmodule Dawdle.Backend.LocalTest do
     test "receiving a message" do
       message = Lorem.sentence()
 
-      :ok = Local.send([message])
+      :ok = Local.send(message)
 
       assert {:ok, [message]} = Local.recv()
     end
@@ -70,7 +61,8 @@ defmodule Dawdle.Backend.LocalTest do
       message1 = Lorem.sentence()
       message2 = Lorem.sentence()
 
-      :ok = Local.send([message1, message2])
+      :ok = Local.send(message1)
+      :ok = Local.send(message2)
 
       assert {:ok, [message1, message2]} = Local.recv()
     end
@@ -84,7 +76,7 @@ defmodule Dawdle.Backend.LocalTest do
 
       Process.sleep(10)
 
-      :ok = Local.send([message])
+      :ok = Local.send(message)
     end
   end
 end

--- a/test/dawdle/backend/sqs_test.exs
+++ b/test/dawdle/backend/sqs_test.exs
@@ -13,9 +13,7 @@ defmodule Dawdle.Backend.SQSTest do
   end
 
   setup do
-    queue = hd(SQS.queues())
-
-    {:ok, queue: queue}
+    {:ok, queue: SQS.queue()}
   end
 
   describe "send/1" do
@@ -111,7 +109,7 @@ defmodule Dawdle.Backend.SQSTest do
   end
 
   describe "recv/1" do
-    test "receiving messages", %{queue: q} do
+    test "receiving messages" do
       messages = [Lorem.sentence()]
 
       with_mock ExAws,
@@ -126,11 +124,11 @@ defmodule Dawdle.Backend.SQSTest do
                     _ ->
           {:ok, %{body: %{messages: messages}}}
         end do
-        assert {:ok, messages} = SQS.recv(q)
+        assert {:ok, messages} = SQS.recv()
       end
     end
 
-    test "empty receives", %{queue: q} do
+    test "empty receives" do
       messages = [Lorem.sentence()]
       {:ok, agent} = Agent.start_link(fn -> true end)
 
@@ -151,21 +149,21 @@ defmodule Dawdle.Backend.SQSTest do
             {:ok, %{body: %{messages: messages}}}
           end
         end do
-        assert {:ok, messages} = SQS.recv(q)
+        assert {:ok, messages} = SQS.recv()
       end
     end
 
-    test "receiving messages when there is an error", %{queue: q} do
+    test "receiving messages when there is an error" do
       with_mock ExAws, request: fn _, _ -> {:error, :testing} end do
         assert capture_log(fn ->
-                 assert {:error, :testing} = SQS.recv(q)
+                 assert {:error, :testing} = SQS.recv()
                end) =~ "{:error, :testing}"
       end
     end
   end
 
   describe "delete/2" do
-    test "deleting messages", %{queue: q} do
+    test "deleting messages" do
       messages = [%{receipt_handle: 1}]
 
       with_mock ExAws,
@@ -181,16 +179,16 @@ defmodule Dawdle.Backend.SQSTest do
                     _ ->
           {:ok, :testing}
         end do
-        assert :ok = SQS.delete(q, messages)
+        assert :ok = SQS.delete(messages)
       end
     end
 
-    test "deleting messages when there is an error", %{queue: q} do
+    test "deleting messages when there is an error" do
       messages = [%{receipt_handle: 1}]
 
       with_mock ExAws, request: fn _, _ -> {:error, :testing} end do
         assert capture_log(fn ->
-                 assert {:error, :testing} = SQS.delete(q, messages)
+                 assert {:error, :testing} = SQS.delete(messages)
                end) =~ "{:error, :testing}"
       end
     end

--- a/test/dawdle/backend/sqs_test.exs
+++ b/test/dawdle/backend/sqs_test.exs
@@ -32,46 +32,14 @@ defmodule Dawdle.Backend.SQSTest do
                     _ ->
           {:ok, "testing"}
         end do
-        assert :ok = SQS.send([message])
+        assert :ok = SQS.send(message)
       end
     end
 
     test "sending a single message when there is an error" do
       with_mock ExAws, request: fn _, _ -> {:error, :testing} end do
         assert capture_log(fn ->
-                 assert {:error, :testing} = SQS.send([Lorem.sentence()])
-               end) =~ "{:error, :testing}"
-      end
-    end
-
-    test "sending multiple messages" do
-      message1 = Lorem.sentence()
-      message2 = Lorem.sentence()
-
-      with_mock ExAws,
-        request: fn %Query{
-                      action: :send_message_batch,
-                      service: :sqs,
-                      params: %{
-                        "Action" => "SendMessageBatch",
-                        "SendMessageBatchRequestEntry.1.MessageBody" =>
-                          ^message1,
-                        "SendMessageBatchRequestEntry.2.MessageBody" =>
-                          ^message2
-                      }
-                    },
-                    _ ->
-          {:ok, "testing"}
-        end do
-        assert :ok = SQS.send([message1, message2])
-      end
-    end
-
-    test "sending multiple messages when there is an error" do
-      with_mock ExAws, request: fn _, _ -> {:error, :testing} end do
-        assert capture_log(fn ->
-                 assert {:error, :testing} =
-                          SQS.send([Lorem.sentence(), Lorem.sentence()])
+                 assert {:error, :testing} = SQS.send(Lorem.sentence())
                end) =~ "{:error, :testing}"
       end
     end
@@ -163,32 +131,31 @@ defmodule Dawdle.Backend.SQSTest do
   end
 
   describe "delete/2" do
-    test "deleting messages" do
-      messages = [%{receipt_handle: 1}]
+    test "deleting a message" do
+      message = %{receipt_handle: 1}
 
       with_mock ExAws,
         request: fn %Query{
-                      action: :delete_message_batch,
+                      action: :delete_message,
                       service: :sqs,
                       params: %{
-                        "Action" => "DeleteMessageBatch",
-                        "DeleteMessageBatchRequestEntry.1.Id" => "0",
-                        "DeleteMessageBatchRequestEntry.1.ReceiptHandle" => 1
+                        "Action" => "DeleteMessage",
+                        "ReceiptHandle" => 1
                       }
                     },
                     _ ->
           {:ok, :testing}
         end do
-        assert :ok = SQS.delete(messages)
+        assert :ok = SQS.delete(message)
       end
     end
 
     test "deleting messages when there is an error" do
-      messages = [%{receipt_handle: 1}]
+      message = %{receipt_handle: 1}
 
       with_mock ExAws, request: fn _, _ -> {:error, :testing} end do
         assert capture_log(fn ->
-                 assert {:error, :testing} = SQS.delete(messages)
+                 assert {:error, :testing} = SQS.delete(message)
                end) =~ "{:error, :testing}"
       end
     end

--- a/test/dawdle/backend_test.exs
+++ b/test/dawdle/backend_test.exs
@@ -20,25 +20,48 @@ defmodule Dawdle.BackendTest do
   test "basic send and receive", %{backend: backend} do
     message = Lorem.sentence()
 
-    assert :ok = backend.send([message])
+    assert :ok = backend.send(message)
     assert {:ok, messages} = backend.recv()
-    assert :ok = backend.delete(messages)
+
+    for msg <- messages do
+      assert :ok = backend.delete(msg)
+    end
 
     assert Enum.any?(messages, fn %{body: msg} -> msg == message end)
   end
 
-  test "send multiple messages", %{backend: backend} do
+  test "receive multiple messages", %{backend: backend} do
     message1 = Lorem.sentence()
     message2 = Lorem.sentence()
 
-    assert :ok = backend.send([message1, message2])
-    assert {:ok, messages} = backend.recv()
-    assert :ok = backend.delete(messages)
+    assert :ok = backend.send(message1)
+    assert :ok = backend.send(message2)
 
-    assert length(messages) >= 2
+    receive_messages(backend, message1, message2)
+  end
 
-    assert Enum.any?(messages, fn %{body: msg} -> msg == message1 end)
-    assert Enum.any?(messages, fn %{body: msg} -> msg == message2 end)
+  defp receive_messages(backend, m1, m2, acc \\ [], count \\ 1)
+
+  defp receive_messages(_, _, _, _, 5) do
+    flunk("Did not receive messages after 5 tries")
+  end
+
+  defp receive_messages(backend, m1, m2, acc, count) do
+    {:ok, messages} = backend.recv()
+
+    for msg <- messages do
+      assert :ok = backend.delete(msg)
+    end
+
+    msgs = acc ++ messages
+
+    if length(msgs) >= 2 &&
+         Enum.any?(msgs, fn %{body: msg} -> msg == m1 end) &&
+         Enum.any?(msgs, fn %{body: msg} -> msg == m2 end) do
+      :ok
+    else
+      receive_messages(backend, m1, m2, msgs, count + 1)
+    end
   end
 
   test "send delayed message", %{backend: backend} do
@@ -49,7 +72,10 @@ defmodule Dawdle.BackendTest do
     Process.sleep(10)
 
     assert {:ok, messages} = backend.recv()
-    assert :ok = backend.delete(messages)
+
+    for msg <- messages do
+      assert :ok = backend.delete(msg)
+    end
 
     assert Enum.any?(messages, fn %{body: msg} -> msg == message end)
   end

--- a/test/dawdle/backend_test.exs
+++ b/test/dawdle/backend_test.exs
@@ -14,33 +14,26 @@ defmodule Dawdle.BackendTest do
   end
 
   setup do
-    backend = Backend.new()
-
-    # This is cheating a little bit to get the queue names
-    message_queue = hd(backend.queues())
-    delay_queue = hd(Enum.reverse(backend.queues()))
-
-    {:ok,
-     backend: backend, message_queue: message_queue, delay_queue: delay_queue}
+    {:ok, backend: Backend.new()}
   end
 
-  test "basic send and receive", %{backend: backend, message_queue: q} do
+  test "basic send and receive", %{backend: backend} do
     message = Lorem.sentence()
 
     assert :ok = backend.send([message])
-    assert {:ok, messages} = backend.recv(q)
-    assert :ok = backend.delete(q, messages)
+    assert {:ok, messages} = backend.recv()
+    assert :ok = backend.delete(messages)
 
     assert Enum.any?(messages, fn %{body: msg} -> msg == message end)
   end
 
-  test "send multiple messages", %{backend: backend, message_queue: q} do
+  test "send multiple messages", %{backend: backend} do
     message1 = Lorem.sentence()
     message2 = Lorem.sentence()
 
     assert :ok = backend.send([message1, message2])
-    assert {:ok, messages} = backend.recv(q)
-    assert :ok = backend.delete(q, messages)
+    assert {:ok, messages} = backend.recv()
+    assert :ok = backend.delete(messages)
 
     assert length(messages) >= 2
 
@@ -48,15 +41,15 @@ defmodule Dawdle.BackendTest do
     assert Enum.any?(messages, fn %{body: msg} -> msg == message2 end)
   end
 
-  test "send delayed message", %{backend: backend, delay_queue: q} do
+  test "send delayed message", %{backend: backend} do
     message = Lorem.sentence()
 
     assert :ok = backend.send_after(message, 1)
 
     Process.sleep(10)
 
-    assert {:ok, messages} = backend.recv(q)
-    assert :ok = backend.delete(q, messages)
+    assert {:ok, messages} = backend.recv()
+    assert :ok = backend.delete(messages)
 
     assert Enum.any?(messages, fn %{body: msg} -> msg == message end)
   end

--- a/test/dawdle/message_encoder/term_test.exs
+++ b/test/dawdle/message_encoder/term_test.exs
@@ -6,6 +6,11 @@ defmodule Dawdle.MessageEncoder.TermTest do
   @data "I sing the body electric"
 
   test "is reversible" do
-    assert @data |> Term.encode() |> Term.decode() == @data
+    assert {:ok, encoded} = Term.encode(@data)
+    assert {:ok, @data} = Term.decode(encoded)
+  end
+
+  test "unrecognized input" do
+    assert {:error, :unrecognized} == Term.decode(@data)
   end
 end

--- a/test/dawdle_test.exs
+++ b/test/dawdle_test.exs
@@ -144,16 +144,6 @@ defmodule DawdleTest do
       assert_receive :handled, 25_000
     end
 
-    test "should send batched events to a single handler" do
-      t = %TestEvent{pid: self()}
-
-      :ok = Dawdle.signal([t, t, t])
-
-      assert_receive :handled, 25_000
-      assert_receive :handled, 25_000
-      assert_receive :handled, 25_000
-    end
-
     test "should send event to mulitple handlers" do
       TestRehandler.register()
 
@@ -198,16 +188,6 @@ defmodule DawdleTest do
 
       :ok = Dawdle.signal(t, direct: true)
 
-      assert_receive :handled
-    end
-
-    test "should send batched events to a single handler" do
-      t = %TestEvent{pid: self()}
-
-      :ok = Dawdle.signal([t, t, t], direct: true)
-
-      assert_receive :handled
-      assert_receive :handled
       assert_receive :handled
     end
 


### PR DESCRIPTION
This improves message throughput in two ways:

1) Use a single standard message queue for all messages
2) Delete each message after it is handled

This PR also removes some deprecated and unnecessary code to simplify things a bit.